### PR TITLE
Update .gitignore to test ci dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+test_ci_dependency


### PR DESCRIPTION
depends-on: [open-vela/test_ci/pull/1]